### PR TITLE
support `-l` `-c` when not installed (`which` fails)

### DIFF
--- a/version
+++ b/version
@@ -131,8 +131,9 @@ tools_xsel=--version
 tools_yarn=version
 tools_zsh=--version
 
-
-
+function list_tools {
+  egrep -o "^tools_[^=]*" $(basename "$0") | grep -oP "tools_\K(.*)"
+}
 
 # User forgot to specify the program or a flag
 if [ -z $1 ]
@@ -160,7 +161,7 @@ fi
 # Display recognized program count
 if [ $1 == -c ]
 then
-  count=$(egrep -o "^tools_[^=]*" $(basename "$0") | wc -l)
+  count=$(list_tools | wc -l)
   echo "I know how to find the versions of $count programs!"
   exit
 fi
@@ -175,7 +176,7 @@ fi
 # Display all the tools we know
 if [ $1 == -l ]
 then
-  egrep -o "^tools_[^=]*" $(basename "$0") | grep -oP "tools_\K(.*)"
+  list_tools
   exit
 fi
 

--- a/version
+++ b/version
@@ -1,4 +1,4 @@
-#! /bin/bash 
+#! /bin/bash
 
 ver="v0.3.3"
 
@@ -160,7 +160,7 @@ fi
 # Display recognized program count
 if [ $1 == -c ]
 then
-  count=$(egrep -o "^tools_" $(which version) | wc -l)
+  count=$(egrep -o "^tools_" $(basename "$0") | wc -l)
   echo "I know how to find the versions of $count programs!"
   exit
 fi
@@ -175,7 +175,7 @@ fi
 # Display all the tools we know
 if [ $1 == -l ]
 then
-  egrep -o "^tools_[^=]*" $(which version) | grep -oP "tools_\K(.*)"
+  egrep -o "^tools_[^=]*" $(basename "$0") | grep -oP "tools_\K(.*)"
   exit
 fi
 
@@ -189,7 +189,7 @@ then
   echo "I don't know how to find the version of '$1'."
   echo "If you figure it out, let me know at https://github.com/bit101/version"
   exit
-fi 
+fi
 
 # display the correct command for the user
 echo "Command: $1 $version_arg"

--- a/version
+++ b/version
@@ -160,7 +160,7 @@ fi
 # Display recognized program count
 if [ $1 == -c ]
 then
-  count=$(egrep -o "^tools_" $(basename "$0") | wc -l)
+  count=$(egrep -o "^tools_[^=]*" $(basename "$0") | wc -l)
   echo "I know how to find the versions of $count programs!"
   exit
 fi


### PR DESCRIPTION
For example, if executed locally in the `git clone` as `./version`.

Also, changed the regex pattern to match.