### PR TITLE
snap: Add CI testing of the snap build process

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+# Builds a snap on a PR/push to the snap branch in order to test new changes.
+
+name: Tests
+
+on:
+  push:
+    branches: [ snap ]
+  pull_request:
+    branches: [ snap ]
+
+jobs:
+  build-snap:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install Snapcraft with LXD
+        uses: samuelmeuli/action-snapcraft@v1.1.2 # For Documentation, see https://github.com/marketplace/actions/snapcraft-action
+        with:
+          use_lxd: true
+
+      - name: Build snap
+        run: sg lxd -c 'snapcraft --use-lxd'
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ success() }}
+        with:
+          name: version.snap
+          path: ./*.snap


### PR DESCRIPTION
This PR makes sure that future commits to this branch (and later `master`) don't mess around with the snap building.
Be advised that the check can take [up to 10 minutes](https://github.com/samuelmeuli/action-snapcraft/blob/master/README.md#build-using-lxd) according to the documentation.
Once we get the snap functioning properly (#21), we could add some real-world usage to the tests as well.