### PR TITLE
fix grep command that didn't work on macos

### DIFF
--- a/version
+++ b/version
@@ -158,7 +158,7 @@ tools_zathura=--version
 tools_zsh=--version
 
 function list_tools {
-  egrep -o "^tools_[^=]*" $(basename "$0") | grep -oP "tools_\K(.*)"
+  egrep -o "^tools_[^=]*" $(basename "$0") | sed 's/tools_\(.*\)/\1/'
 }
 
 # User forgot to specify the program or a flag


### PR DESCRIPTION
The regex in `list_tools` did not work on Macos. This was because it was using the `-P` option for perl regex flavor, which included using `\K` for capture groups to get the tool name. That is only supported in gnugrep now. This was breaking the `-c` and `-l` flags.

Changed this to use `sed` instead.